### PR TITLE
Fix import of reports in ZIP files.

### DIFF
--- a/app/import.script/import.php
+++ b/app/import.script/import.php
@@ -183,7 +183,7 @@ if($emails) {
                     $zip->open('./' . $folder . '/' . $email_number . '-' . $filename);
                     $xmlFilename = $zip->getNameIndex(0);
                     $zip->close();
-                    $xmlRaw = file_get_contents('zip://./' . $folder . '/' . $email_number . '-' . $filename . '#' . $xmlFilename);
+                    $xmlRaw = file_get_contents('zip://' . realpath('./' . $folder . '/' . $email_number . '-' . $filename) . '#' . $xmlFilename);
                     $xml = simplexml_load_string($xmlRaw);
                     unlink('./' . $folder . '/' . $email_number . '-' . $filename);
                 } elseif(preg_match('/.gz$/i',$filename)) {


### PR DESCRIPTION
`file_get_contents` doesn't seem to play well with ZIP files unless it gets the absolute path to the archive.