### PR TITLE
Compatibility enhancement: support uncompressed raw_xml in database

### DIFF
--- a/app/presenters/HomepagePresenter.php
+++ b/app/presenters/HomepagePresenter.php
@@ -383,8 +383,14 @@ class HomepagePresenter extends Nette\Application\UI\Presenter
             $result = $this->database->query($query,$serial)->fetchAll();
         }
         if (isset($result) && count($result) != 0) {
-            $this->template->xmlData = gzdecode(base64_decode($result[0]['raw_xml']));
-            $this->template->jsonData = json_encode(simplexml_load_string(gzdecode(base64_decode($result[0]['raw_xml']))));
+            // attempt base64/gzip decode
+            $raw_xml = gzdecode(base64_decode($result[0]['raw_xml']));
+            if (!$raw_xml) {
+                // fall back to raw xml without decoding
+                $raw_xml = $result[0]['raw_xml'];
+            }
+            $this->template->xmlData = $raw_xml;
+            $this->template->jsonData = json_encode(simplexml_load_string($raw_xml));
         } else {
             $this->template->xmlData = NULL;
             $this->template->jsonData = NULL;


### PR DESCRIPTION
This pull requests adds support for uncompressed raw_xml, which is used by dmarcts parser (by default).
The code assumes compressed XML first, attempts decoding, then falls back to raw XML if decoding fails.